### PR TITLE
Add basic usage information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # Vanilla Starter for Enonic XP
+
+This starter kit will set up the basics for your new Enonic project.
+
+Once initiated, you'll have the bare minimum needed to create a new Enonic
+application or library. You'll have all the folders set up, and can get
+straight to creating what you're creating.
+
+## Usage
+
+To get started, use the `toolbox` script to initiate your project:
+
+```bash
+~ $ mkdir new-project
+~ $ cd new-project
+~/new-project $ [$XP_INSTALL]/toolbox/toolbox.sh init-project -n com.example.name -r starter-vanilla
+```


### PR DESCRIPTION
Every time I'm starting a new project, I go to the "my first app" tutorial to get the `init-project` line. I'm tired of it. 

This patch adds that line and some basic introduction to the readme file.